### PR TITLE
🔀: iOS에서 유효한 인자값으로 수정.

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -12,7 +12,7 @@ from GHJM.json_response_setting import JsonResponse
 from django.views.decorators.http import require_http_methods
 import requests
 
-REFRESH_TOKEN = 'refresh-token'
+REFRESH_TOKEN = 'refreshtoken'
 
 # Create your views here.
 def kakao_login(request):
@@ -115,7 +115,7 @@ def reissue_token(request):
 @require_http_methods(['DELETE'])
 # user가 로그아웃 버튼을 직접 클릭 했을 경우    
 def logout(request):
-    refresh_token = request.headers.get('REFRESH-TOKEN')
+    refresh_token = request.headers.get(REFRESH_TOKEN)
      
     try:
         user_id = decode_token(refresh_token).get('user_id')


### PR DESCRIPTION
## 💡 개요
- 리프레시 토큰 발급시 사용되는 api에서 key명을 iOS에서 사용가능한 key 값으로 변경하였습니다.

## 📃 작업내용
- iOS에서는 언더바 or 하이픈이 포함된 키값을 사용할 수 없다는 것을 확인후, 수정하였습니다.

## 🔀 변경사항


## 🙋‍♂️ 질문사항


## 🎸 기타
